### PR TITLE
MVVM Refactor.

### DIFF
--- a/Controls/Node.xaml.cs
+++ b/Controls/Node.xaml.cs
@@ -53,35 +53,39 @@ namespace CanvasTest.Controls
 
 
         // S E L E C T I O N L O G I C
+        public static readonly DependencyProperty IsSelectedProperty =
+            DependencyProperty.Register("IsSelected", typeof(bool), typeof(Node),
+                new PropertyMetadata(false, OnIsSelectedChanged));
+
+
         private bool _isSelected = false;
         public bool IsSelected
         {
-            get => _isSelected;
-            set
-            {
-                _isSelected = value;
-                UpdateSelectionVisual();
-            }
+            get { return (bool)GetValue(IsSelectedProperty); }
+            set { SetValue(IsSelectedProperty, value); }
         }
+
+        private static void OnIsSelectedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var node = (Node)d;
+            node.UpdateSelectionVisual();
+        }
+
         private void UpdateSelectionVisual()
         {
-            var mainBorder = MainBorder; // Now we have a named reference
-
-            if (mainBorder != null)
+            if (MainBorder != null)
             {
-                if (_isSelected)
+                if (IsSelected)
                 {
-                    // Use harmonized selection color (matches ListBox hover)
-                    mainBorder.BorderBrush = new SolidColorBrush(Color.FromRgb(0x3B, 0x82, 0xF6)); // Blue
-                    mainBorder.BorderThickness = new Thickness(2);
-                    mainBorder.Background = new SolidColorBrush(Color.FromRgb(0xEB, 0xF8, 0xFF)); // Light blue bg
+                    MainBorder.BorderBrush = new SolidColorBrush(Color.FromRgb(0x3B, 0x82, 0xF6)); // Blue
+                    MainBorder.BorderThickness = new Thickness(2);
+                    MainBorder.Background = new SolidColorBrush(Color.FromRgb(0xEB, 0xF8, 0xFF)); // Light blue bg
                 }
                 else
                 {
-                    // Default harmonized colors
-                    mainBorder.BorderBrush = new SolidColorBrush(Color.FromRgb(0xE1, 0xE5, 0xE9)); // Light gray
-                    mainBorder.BorderThickness = new Thickness(1);
-                    mainBorder.Background = new SolidColorBrush(Colors.White);
+                    MainBorder.BorderBrush = new SolidColorBrush(Color.FromRgb(0xE1, 0xE5, 0xE9)); // Light gray
+                    MainBorder.BorderThickness = new Thickness(1);
+                    MainBorder.Background = new SolidColorBrush(Colors.White);
                 }
             }
         }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -7,14 +7,6 @@
         xmlns:controls="clr-namespace:CanvasTest.Controls"
         xmlns:converters="clr-namespace:CanvasTest.Converters"
         KeyDown="MainWindow_KeyDown"
-        PreviewMouseUp="MainWindow_PreviewMouseUp"
-        MouseMove="MainWindow_MouseMove"
-        MouseLeftButtonDown="MainWindow_MouseLeftButtonDown"
-        MouseLeftButtonUp="MainWindow_MouseLeftButtonUp"
-        MouseRightButtonDown="MainWindow_MouseRightButtonDown"
-        MouseRightButtonUp="MainWindow_MouseRightButtonUp"
-        MouseDown="MainWindow_MouseDown"
-        MouseUp="MainWindow_MouseUp"
         mc:Ignorable="d"
         Title="Visual Excel Canvas" Height="800" Width="1000">
     <Window.Resources>
@@ -172,16 +164,14 @@
 
                 <!--Function List-->
                 <ListBox Grid.Row="2"
-                         ItemsSource="{Binding FilteredFunctions}"
-                         x:Name="FunctionListBox"
-                         PreviewMouseLeftButtonDown="FunctionListBox_PreviewMouseLeftButtonDown"
-                         MouseMove="FunctionListBox_MouseMove"
-                         MouseLeave="FunctionListBox_MouseLeave"
-                         Background="#F8F9FA"
-                         BorderThickness="0"
-                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                         Panel.ZIndex="1"
-                         Padding="0 0 5 0">
+         ItemsSource="{Binding FilteredFunctions}"
+         x:Name="FunctionListBox"
+         PreviewMouseLeftButtonDown="FunctionListBox_PreviewMouseLeftButtonDown"
+         Background="#F8F9FA"
+         BorderThickness="0"
+         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+         Panel.ZIndex="1"
+         Padding="0 0 5 0">
 
 
                     <ListBox.ItemTemplate>
@@ -287,82 +277,88 @@
             <Grid Grid.Column="1" ClipToBounds="True">
                 <Rectangle Fill="{StaticResource GridBrushMinor}"/>
                 <Rectangle Fill="{StaticResource GridBrushMajor}"/>
-                
+
                 <Canvas 
                                 x:Name="NodeCanvas" 
                                 Background="Transparent"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
                                 MouseLeftButtonDown="NodeCanvas_LeftButtonDown" 
-                                MouseLeftButtonUp="NodeCanvas_LeftButtonUp" 
-                        MouseRightButtonUp="NodeCanvas_RightButtonUp"        
-                        MouseMove="NodeCanvas_MouseMove"
                                 AllowDrop="True"
                                 Drop="NodeCanvas_Drop"
-                                DragEnter="NodeCanvas_DragEnter"
-                                DragLeave="NodeCanvas_DragLeave">
+                                DragEnter="NodeCanvas_DragEnter">
 
+                    <ItemsControl ItemsSource="{Binding Nodes}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
 
-                    <!-- nodes get added as children here in NodeCanvas_Drop-->
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding X}" />
+                                <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <controls:Node 
+                                        FunctionName="{Binding FunctionName}"
+                                        NodeValue="{Binding NodeValue}"
+                                        IconPath="{Binding IconPath}"
+                                        IsSelected="{Binding IsSelected, Mode=TwoWay}"
+                                        MouseLeftButtonDown="Node_LeftButtonDown"
+                                        MouseMove="Node_MouseMove"
+                                        MouseLeftButtonUp="Node_LeftButtonUp"
+                    />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
                 </Canvas>
             </Grid>
             <!-- Debug and Properties Panel-->
-            <Expander Grid.Column="2" Name="PropertiesPanel" Background="#FAFBFC" BorderBrush="#2b579a" BorderThickness="0.5"
-                        HorizontalAlignment="Right" Header="" 
-                        ExpandDirection="Left" IsExpanded="True" Width="Auto"
-                      Collapsed="PropertiesPanel_Collapsed">
-                <Grid>
+            <Expander Header="Properties" Grid.Column="2" Name="PropertiesPanel"
+          HorizontalAlignment="Right"
+          ExpandDirection="Left" IsExpanded="True"
+          DataContext="{Binding SelectedNode}">
+                <Grid Margin="10" MinWidth="250">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="*"/>
-                        <!--Properties-->
-                        <RowDefinition Height="550"/>
-                        <!--Debug-->
-
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <!--Properties-->
-                    <StackPanel Grid.Row="0">
-                        <TextBlock>Properties</TextBlock>
-                    </StackPanel>
 
+                    <Grid.Style>
+                        <Style TargetType="Grid">
+                            <Setter Property="Visibility" Value="Visible" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding}" Value="{x:Null}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Grid.Style>
 
+                    <TextBlock Text="GUID:" FontWeight="Bold" Margin="0,0,10,5" Grid.Row="0" Grid.Column="0"/>
+                    <TextBox Text="{Binding Id, Mode=OneWay}" IsReadOnly="True" Grid.Row="0" Grid.Column="1"/>
 
-                    <!--Debug-->
-                    <StackPanel Grid.Row="1" VerticalAlignment="Top">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <!--debug Fields-->
-                                <ColumnDefinition Width="*"/>
-                                <!--debug Data-->
-                            </Grid.ColumnDefinitions>
+                    <TextBlock Text="Function:" FontWeight="Bold" Margin="0,0,10,5" Grid.Row="1" Grid.Column="0"/>
+                    <TextBox Text="{Binding FunctionName, Mode=OneWay}" IsReadOnly="True" Grid.Row="1" Grid.Column="1"/>
 
-                            <Grid Grid.Column="0">
-                                <Rectangle x:Name="debugMouseLeft" Width="10" Height ="25" Stroke="black" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="35 20 20 20"/>
-                                <Rectangle x:Name="debugMouseMiddle" Width="10" Height ="25" Stroke="black" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="20 20 20 20"/>
-                                <Rectangle x:Name="debugMouseRight" Width="10" Height ="25" Stroke="black" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="20 20 35 35"/>
+                    <TextBlock Text="Position X:" FontWeight="Bold" Margin="0,0,10,5" Grid.Row="2" Grid.Column="0"/>
+                    <TextBox Text="{Binding X, StringFormat={}{0:F0}}" IsReadOnly="True" Grid.Row="2" Grid.Column="1"/>
 
-                                <Rectangle Width="30" Height="50" Stroke=" black" Margin="20 20 20 20"/>
-                            </Grid>
-                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                <TextBlock x:Name ="debugPanelXCoord"/>
-                                <TextBlock x:Name ="debugPanelYCoord"/>
-                            </StackPanel>
-                        </Grid>
-                        <Grid>
+                    <TextBlock Text="Position Y:" FontWeight="Bold" Margin="0,0,10,5" Grid.Row="3" Grid.Column="0"/>
+                    <TextBox Text="{Binding Y, StringFormat={}{0:F0}}" IsReadOnly="True" Grid.Row="3" Grid.Column="1"/>
 
-                            <StackPanel Width="200">
-                                <TextBlock Text="Node Dragstate: " Background="YellowGreen"/>
-                                <TextBlock Text="{Binding IsNodeDragging}" Foreground="White" Background="Gray" Margin="0 0 20 20"/>
-                                <TextBlock Text="Connection DragState:" Background="YellowGreen"/>
-                                <TextBlock Text="{Binding IsConnectionDragging}" Foreground="White" Background="Gray" Margin="0 0 20 20"/>
-                                
-                                <TextBlock Text="startposition:" Background="YellowGreen"/>
-                                <TextBlock Text="{Binding NodeOriginalPosition}" Foreground="White" Background="Gray" Margin="0 0 20 20"/>
-                                                                <TextBlock Text="Element under mouse:" Background="YellowGreen"/>
-                                <TextBlock x:Name="debugHoveredElement" Foreground="white" Background="Gray" TextWrapping="WrapWithOverflow" Margin="0 0 20 20"/>
-                            </StackPanel>
-                        </Grid>
-                    </StackPanel>
                 </Grid>
             </Expander>
         </Grid>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,155 +1,106 @@
-﻿// ViewModels/MainViewModel.cs
-using CanvasTest.Models;
+﻿using CanvasTest.Models;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
-using System.Windows;
 
-namespace CanvasTest.ViewModels  // Add .ViewModels here
+namespace CanvasTest.ViewModels
 {
-    public class MainViewModel : INotifyPropertyChanged // define the MainViewModel class + implement Interface for telling ui when ViewModel has changed.
+    public class MainViewModel : INotifyPropertyChanged
     {
-        public ObservableCollection<ExcelFunction> AvailableFunctions { get; set; } /* define the AvailableFunctions property to hold available 
-                                                                                      Excel functions,  ObservableCollection Notifies the UI that the list has 
-                                                                                        been updated. allow get and set methods*/
-        public event PropertyChangedEventHandler PropertyChanged;
-        public virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-
-
-        #region Search and filtering logic
-        //specific to buttons, ICommand + ICollectionView
-        
-        public ICommand ClearSearchCommand { get; }
-
-        private string _searchText;
-        public readonly ObservableCollection<ExcelFunction> _allFunctions;
-
+        // --- Properties for the Search/Filter ListBox ---
         public ICollectionView FilteredFunctions { get; }
-
-        public bool IsClearButtonVisible => !string.IsNullOrEmpty(SearchText);
-
+        private readonly ObservableCollection<ExcelFunction> _allFunctions;
+        private string _searchText = string.Empty;
         public string SearchText
         {
             get => _searchText;
             set
             {
-                if (_searchText != value) //only triggers if the value has actually changed
+                if (_searchText != value)
                 {
                     _searchText = value;
-                    OnPropertyChanged(); // Notify UI that SearchText has changed
-                    OnPropertyChanged(nameof(IsClearButtonVisible)); //Tell the UI that the dependent property has also changed!
-                    FilteredFunctions.Refresh(); // Trigger the filter to be re-applied
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(IsClearButtonVisible));
+                    FilteredFunctions.Refresh();
                 }
             }
         }
-        
-        // Rulebook for the ICollectionView MainViewModel.FilteredFunctions.Filter method.
+        public bool IsClearButtonVisible => !string.IsNullOrEmpty(SearchText);
+        public ICommand ClearSearchCommand { get; }
+
+
+        // --- Properties for the Node Canvas ---
+
+        // This MUST be public for the UI to bind to it.
+        public ObservableCollection<NodeViewModel> Nodes { get; } = new ObservableCollection<NodeViewModel>();
+
+        private NodeViewModel? _selectedNode;
+        public NodeViewModel? SelectedNode
+        {
+            get => _selectedNode;
+            set
+            {
+                if (_selectedNode != value)
+                {
+                    if (_selectedNode != null) _selectedNode.IsSelected = false;
+                    _selectedNode = value;
+                    if (_selectedNode != null) _selectedNode.IsSelected = true;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        public ICommand DeleteSelectedNodeCommand { get; }
+
+
+        // --- Constructor ---
+        public MainViewModel()
+        {
+            _allFunctions = new ObservableCollection<ExcelFunction>(ExcelFunction.GetAvailableFunctions());
+            FilteredFunctions = CollectionViewSource.GetDefaultView(_allFunctions);
+            FilteredFunctions.Filter = FilterFunctions;
+
+            ClearSearchCommand = new RelayCommand(p => SearchText = string.Empty);
+            DeleteSelectedNodeCommand = new RelayCommand(p => DeleteSelectedNode(), p => SelectedNode != null);
+        }
+
+        // --- Methods to Manipulate the Canvas ---
+        public void AddNode(ExcelFunction function, Point position)
+        {
+            var newNode = new NodeViewModel(function, position.X, position.Y);
+            Nodes.Add(newNode);
+            SelectedNode = newNode;
+        }
+
+        public void DeleteSelectedNode()
+        {
+            if (SelectedNode != null)
+            {
+                Nodes.Remove(SelectedNode);
+                SelectedNode = null;
+            }
+        }
 
         private bool FilterFunctions(object item)
         {
-            if (string.IsNullOrEmpty(SearchText))
-            {
-                return true; // No filter, show all items
-            }
-
+            if (string.IsNullOrEmpty(SearchText)) return true;
             if (item is ExcelFunction function)
             {
-                return function.Name.IndexOf(SearchText, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                       function.Description.IndexOf(SearchText, StringComparison.OrdinalIgnoreCase) >= 0;
+                return function.Name.IndexOf(SearchText, System.StringComparison.OrdinalIgnoreCase) >= 0 ||
+                       function.Description.IndexOf(SearchText, System.StringComparison.OrdinalIgnoreCase) >= 0;
             }
-
             return false;
         }
 
-        private void ClearSearch(object parameter)
+
+        // --- INotifyPropertyChanged Implementation ---
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
-            SearchText = string.Empty;
-        }
-
-        #endregion
-
-        public MainViewModel() // constructor for MainViewModel class
-        {
-            //AvailableFunctions = new ObservableCollection<ExcelFunction>( // initialize the AvailableFunctions property with a ->//
-            //    ExcelFunction.GetAvailableFunctions()                     //->  collection of ExcelFunction objects
-            //);
-            _allFunctions = new ObservableCollection<ExcelFunction>(ExcelFunction.GetAvailableFunctions()); //instantiate a new list from the Model
-            FilteredFunctions = CollectionViewSource.GetDefaultView(_allFunctions); //Initial condition of the list
-            FilteredFunctions.Filter = FilterFunctions; //Setting the .Filter method rulebook
-
-            ClearSearchCommand = new RelayCommand(ClearSearch);
-        }
-
-        #region Dragging properties and logic for UI
-        //Drag state for nodes
-        private bool _isNodeDragging;
-        public bool IsNodeDragging
-        {
-            get => _isNodeDragging;
-            set
-            {
-                if (_isNodeDragging != value)
-                {
-                    _isNodeDragging = value;
-                    OnPropertyChanged(); // This notifies the UI to update
-                }
-            }
-        }
-
-        //Drag State for Connections
-        private bool _isConnectionDragging;
-        public bool IsConnectionDragging
-        {
-            get => _isConnectionDragging;
-            set
-            {
-                if (_isConnectionDragging != value)
-                {
-                    _isConnectionDragging = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
-
-            //Continutous 'new' starting position for calculation of the mousemove
-            //NOT THE ORIGINAL POSITION
-        private Point _nodeDragPreviousPosition;
-        public Point NodeDragPreviousPosition
-        {
-            get => _nodeDragPreviousPosition;
-            set
-            {
-                if (_nodeDragPreviousPosition != value)
-                {
-                    _nodeDragPreviousPosition = value;
-                    OnPropertyChanged();
-                }
-            }
-
-        }
-
-        //Gets the node's original position for drag canelling
-        private Point _nodeOriginalPosition;
-        public Point NodeOriginalPosition
-        {
-            get => _nodeOriginalPosition;
-            set
-            {
-                if (_nodeOriginalPosition != value)
-                {
-                    _nodeOriginalPosition = value;
-                    OnPropertyChanged();
-                }
-            }
-
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
-    #endregion
 }

--- a/ViewModels/NodeViewModel.cs
+++ b/ViewModels/NodeViewModel.cs
@@ -17,14 +17,14 @@ namespace CanvasTest.ViewModels
         public ExcelFunction FunctionModel { get; }
 
         private double _x;
-        private double X
+        public double X
         {
             get => _x;
             set { _x = value; OnPropertyChanged(); }
         }
 
         private double _y;
-        private double Y
+        public double Y
         {
             get => _y;
             set { _y = value; OnPropertyChanged(); }
@@ -43,7 +43,6 @@ namespace CanvasTest.ViewModels
                 }
             }
         }
-
         //Properties to be displayed by the UI
         public string FunctionName => FunctionModel.Name;
         public string IconPath => FunctionModel.IconPath;


### PR DESCRIPTION
drag handlers moved to the MainViewModel and NodeViewModel in preparation for various iteration tasks such as dynamic canvas sizing and multi-selection via drag box. This also serves to build a data structure for storing the nodes, retrieving their properties etc. in preparation for implementing the connection logic - don't know how far im going to get with this so it's a new branch :s